### PR TITLE
Fix Null Pointer Exception on TIM Re-submission Due to Missing Frame Type Value

### DIFF
--- a/cv-data-controller/src/main/java/com/trihydro/cvdatacontroller/controller/ActiveTimController.java
+++ b/cv-data-controller/src/main/java/com/trihydro/cvdatacontroller/controller/ActiveTimController.java
@@ -172,6 +172,12 @@ public class ActiveTimController extends BaseController {
 				if (!rs.wasNull() && frameTypeValue >= 0 && frameTypeValue < TravelerInfoType.values().length) {
 					activeTim.setFrameType(TravelerInfoType.values()[frameTypeValue]);
 				}
+				else {
+					utility.logWithDate("Could not set frame type from value " + frameTypeValue
+						+ " for active tim id " + activeTim.getActiveTimId() + ". Assuming Advisory.");
+					// assume advisory
+					activeTim.setFrameType(TravelerInfoType.advisory);
+				}
 
 				// set dataFrame content. it's required for the ODE, so if we didn't record it,
 				// assume Advisory
@@ -302,6 +308,12 @@ public class ActiveTimController extends BaseController {
 				int frameTypeValue = rs.getInt("FRAME_TYPE");
 				if (!rs.wasNull() && frameTypeValue >= 0 && frameTypeValue < TravelerInfoType.values().length) {
 					activeTim.setFrameType(TravelerInfoType.values()[frameTypeValue]);
+				}
+				else {
+					utility.logWithDate("Could not set frame type from value " + frameTypeValue
+							+ " for active tim id " + activeTimId + ". Assuming Advisory.");
+					// assume advisory
+					activeTim.setFrameType(TravelerInfoType.advisory);
 				}
 
 				// set dataFrame content. it's required for the ODE, so if we didn't record it,


### PR DESCRIPTION
## Problem  
Re-submitting a TIM results in a null pointer exception because the frame type element is missing:

> java.lang.NullPointerException: Cannot invoke "com.fasterxml.jackson.databind.JsonNode.asText()" because the return value of "com.fasterxml.jackson.databind.node.ObjectNode.get(String)" is null

## Solution
A commit has been cherry-picked from upstream that improved the frame type value resolution in `ActiveTimController` to default to "advisory" when the original value is invalid or missing.

**Disclaimer**: This solution may be addressing a symptom rather than the root cause. Further investigation into why the frame type value could not be used may be necessary.

## Testing  
Confirmed that re-submitting a TIM works correctly when the original frame type value is missing or unusable.