### PR TITLE
Refactor RsuController to use PreparedStatement

### DIFF
--- a/cv-data-controller/src/main/java/com/trihydro/cvdatacontroller/controller/RsuController.java
+++ b/cv-data-controller/src/main/java/com/trihydro/cvdatacontroller/controller/RsuController.java
@@ -4,7 +4,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,18 +35,19 @@ public class RsuController extends BaseController {
         String query = "select rsu_id, ST_X(ST_AsText(geography)) as longitude, ST_Y(ST_AsText(geography)) as latitude, ipv4_address, primary_route, milepost from rsus order by milepost asc";
 
         try (Connection connection = dbInteractions.getConnectionPool();
-             Statement statement = connection.createStatement();
-             ResultSet rs = statement.executeQuery(query)) {
+             PreparedStatement statement = connection.prepareStatement(query)) {
 
-            while (rs.next()) {
-                WydotRsu rsu = new WydotRsu();
-                rsu.setRsuId(rs.getInt("RSU_ID"));
-                rsu.setRsuTarget(rs.getString("IPV4_ADDRESS"));
-                rsu.setLatitude(rs.getBigDecimal("LATITUDE"));
-                rsu.setLongitude(rs.getBigDecimal("LONGITUDE"));
-                rsu.setRoute(rs.getString("PRIMARY_ROUTE"));
-                rsu.setMilepost(rs.getDouble("MILEPOST"));
-                rsus.add(rsu);
+            try(ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    WydotRsu rsu = new WydotRsu();
+                    rsu.setRsuId(rs.getInt("RSU_ID"));
+                    rsu.setRsuTarget(rs.getString("IPV4_ADDRESS"));
+                    rsu.setLatitude(rs.getBigDecimal("LATITUDE"));
+                    rsu.setLongitude(rs.getBigDecimal("LONGITUDE"));
+                    rsu.setRoute(rs.getString("PRIMARY_ROUTE"));
+                    rsu.setMilepost(rs.getDouble("MILEPOST"));
+                    rsus.add(rsu);
+                }
             }
 
         } catch (SQLException e) {
@@ -68,23 +68,26 @@ public class RsuController extends BaseController {
                         "as longitude, ST_Y(ST_AsText(rsus.geography)) as latitude, rsus.ipv4_address, " +
                         "tim_rsu.rsu_index from rsus inner join rsu_credentials on " +
                         "rsu_credentials.credential_id = rsus.credential_id inner join tim_rsu on " +
-                        "tim_rsu.rsu_id = rsus.rsu_id where tim_rsu.tim_id = " + timId;
+                        "tim_rsu.rsu_id = rsus.rsu_id where tim_rsu.tim_id = ?";
 
         try(Connection connection = dbInteractions.getConnectionPool();
-            Statement statement = connection.createStatement();
-            ResultSet rs = statement.executeQuery(query)) {
+            PreparedStatement statement = connection.prepareStatement(query)) {
 
-            while (rs.next()) {
-                WydotRsuTim rsu = new WydotRsuTim();
-                rsu.setRsuTarget(rs.getString("IPV4_ADDRESS"));
-                rsu.setLatitude(rs.getBigDecimal("LATITUDE"));
-                rsu.setLongitude(rs.getBigDecimal("LONGITUDE"));
-                rsu.setIndex(rs.getInt("RSU_INDEX"));
-                rsu.setRsuUsername(rs.getString("UPDATE_USERNAME"));
-                rsu.setRsuPassword(rs.getString("UPDATE_PASSWORD"));
-                // only add unique values in
-                if (!rsus.contains(rsu)) {
-                    rsus.add(rsu);
+            statement.setLong(1, timId);
+
+            try(ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    WydotRsuTim rsu = new WydotRsuTim();
+                    rsu.setRsuTarget(rs.getString("IPV4_ADDRESS"));
+                    rsu.setLatitude(rs.getBigDecimal("LATITUDE"));
+                    rsu.setLongitude(rs.getBigDecimal("LONGITUDE"));
+                    rsu.setIndex(rs.getInt("RSU_INDEX"));
+                    rsu.setRsuUsername(rs.getString("UPDATE_USERNAME"));
+                    rsu.setRsuPassword(rs.getString("UPDATE_PASSWORD"));
+                    // only add unique values in
+                    if (!rsus.contains(rsu)) {
+                        rsus.add(rsu);
+                    }
                 }
             }
         } catch (SQLException e) {
@@ -108,23 +111,26 @@ public class RsuController extends BaseController {
                 "JOIN organizations AS o ON ro.organization_id = o.organization_id " +
                 "WHERE o.name = 'Region 1') " +
                 "AND ST_Intersects(" +
-                "ST_Buffer(ST_GeomFromText('" + geometry + "'), 1), geography)";
+                "ST_Buffer(ST_GeomFromText(?), 1), geography)";
 
         try(Connection connection = dbInteractions.getConnectionPool();
-            Statement statement = connection.createStatement();
-            ResultSet rs = statement.executeQuery(query)) {
+            PreparedStatement statement = connection.prepareStatement(query)) {
 
-            while (rs.next()) {
-                WydotRsu rsu = new WydotRsu();
-                rsu.setRsuId(rs.getInt("RSU_ID"));
-                rsu.setRsuTarget(rs.getString("IPV4_ADDRESS"));
-                rsu.setLatitude(rs.getBigDecimal("LATITUDE"));
-                rsu.setLongitude(rs.getBigDecimal("LONGITUDE"));
-                rsu.setRoute(rs.getString("PRIMARY_ROUTE"));
-                rsu.setMilepost(rs.getDouble("MILEPOST"));
-                rsu.setRsuUsername(rs.getString("USERNAME"));
-                rsu.setRsuPassword(rs.getString("PASSWORD"));
-                rsus.add(rsu);
+            statement.setString(1, geometry);
+
+            try(ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    WydotRsu rsu = new WydotRsu();
+                    rsu.setRsuId(rs.getInt("RSU_ID"));
+                    rsu.setRsuTarget(rs.getString("IPV4_ADDRESS"));
+                    rsu.setLatitude(rs.getBigDecimal("LATITUDE"));
+                    rsu.setLongitude(rs.getBigDecimal("LONGITUDE"));
+                    rsu.setRoute(rs.getString("PRIMARY_ROUTE"));
+                    rsu.setMilepost(rs.getDouble("MILEPOST"));
+                    rsu.setRsuUsername(rs.getString("USERNAME"));
+                    rsu.setRsuPassword(rs.getString("PASSWORD"));
+                    rsus.add(rsu);
+                }
             }
         } catch (SQLException e) {
             log.error("Exception", e);
@@ -138,21 +144,24 @@ public class RsuController extends BaseController {
         ArrayList<WydotRsu> rsus = new ArrayList<WydotRsu>();
 
         // select all RSUs from RSU table
-        String query = "select rsu_id, ST_X(ST_AsText(geography)) as longitude, ST_Y(ST_AsText(geography)) as latitude, ipv4_address, primary_route, milepost from rsus where primary_route like '%" + route + "%'";
+        String query = "select rsu_id, ST_X(ST_AsText(geography)) as longitude, ST_Y(ST_AsText(geography)) as latitude, ipv4_address, primary_route, milepost from rsus where primary_route like ?";
 
         try(Connection connection = dbInteractions.getConnectionPool();
-            Statement statement = connection.createStatement();
-            ResultSet rs = statement.executeQuery(query)) {
+            PreparedStatement statement = connection.prepareStatement(query)) {
 
-            while (rs.next()) {
-                WydotRsu rsu = new WydotRsu();
-                rsu.setRsuId(rs.getInt("RSU_ID"));
-                rsu.setRsuTarget(rs.getString("IPV4_ADDRESS"));
-                rsu.setLatitude(rs.getBigDecimal("LATITUDE"));
-                rsu.setLongitude(rs.getBigDecimal("LONGITUDE"));
-                rsu.setRoute(rs.getString("ROUTE"));
-                rsu.setMilepost(rs.getDouble("MILEPOST"));
-                rsus.add(rsu);
+            statement.setString(1, "%" + route + "%");
+
+            try(ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    WydotRsu rsu = new WydotRsu();
+                    rsu.setRsuId(rs.getInt("RSU_ID"));
+                    rsu.setRsuTarget(rs.getString("IPV4_ADDRESS"));
+                    rsu.setLatitude(rs.getBigDecimal("LATITUDE"));
+                    rsu.setLongitude(rs.getBigDecimal("LONGITUDE"));
+                    rsu.setRoute(rs.getString("ROUTE"));
+                    rsu.setMilepost(rs.getDouble("MILEPOST"));
+                    rsus.add(rsu);
+                }
             }
         } catch (SQLException e) {
             log.error("Exception", e);

--- a/cv-data-controller/src/test/java/com/trihydro/cvdatacontroller/controller/RsuControllerTest.java
+++ b/cv-data-controller/src/test/java/com/trihydro/cvdatacontroller/controller/RsuControllerTest.java
@@ -27,14 +27,16 @@ public class RsuControllerTest extends TestBase<RsuController> {
 
         // Assert
         Assertions.assertEquals(HttpStatus.OK, data.getStatusCode());
-        verify(mockStatement).executeQuery(selectStatement);
+
+        verify(mockConnection).prepareStatement(selectStatement);
+        verify(mockPreparedStatement).executeQuery();
         verify(mockRs).getInt("RSU_ID");
         verify(mockRs).getString("IPV4_ADDRESS");
         verify(mockRs).getBigDecimal("LATITUDE");
         verify(mockRs).getBigDecimal("LONGITUDE");
         verify(mockRs).getString("PRIMARY_ROUTE");
         verify(mockRs).getDouble("MILEPOST");
-        verify(mockStatement).close();
+        verify(mockPreparedStatement).close();
         verify(mockConnection).close();
         verify(mockRs).close();
     }
@@ -44,13 +46,15 @@ public class RsuControllerTest extends TestBase<RsuController> {
         // Arrange
         String selectStatement = "select rsu_id, ST_X(ST_AsText(geography)) as longitude, ST_Y(ST_AsText(geography)) as latitude, ipv4_address, primary_route, milepost from rsus order by milepost asc";
         doThrow(new SQLException()).when(mockRs).getInt("RSU_ID");
+
         // Act
         ResponseEntity<List<WydotRsu>> data = uut.selectAllRsus();
 
         // Assert
         Assertions.assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, data.getStatusCode());
-        verify(mockStatement).executeQuery(selectStatement);
-        verify(mockStatement).close();
+        verify(mockConnection).prepareStatement(selectStatement);
+        verify(mockPreparedStatement).executeQuery();
+        verify(mockPreparedStatement).close();
         verify(mockConnection).close();
         verify(mockRs).close();
     }
@@ -63,21 +67,23 @@ public class RsuControllerTest extends TestBase<RsuController> {
         "rsu_credentials.password as update_password, ST_X(ST_AsText(rsus.geography)) as longitude, " + 
         "ST_Y(ST_AsText(rsus.geography)) as latitude, rsus.ipv4_address, tim_rsu.rsu_index from rsus " + 
         "inner join rsu_credentials on rsu_credentials.credential_id = rsus.credential_id inner join " + 
-        "tim_rsu on tim_rsu.rsu_id = rsus.rsu_id where tim_rsu.tim_id = " + timId;
+        "tim_rsu on tim_rsu.rsu_id = rsus.rsu_id where tim_rsu.tim_id = ?";
 
         // Act
         ResponseEntity<List<WydotRsuTim>> data = uut.getFullRsusTimIsOn(timId);
 
         // Assert
         Assertions.assertEquals(HttpStatus.OK, data.getStatusCode());
-        verify(mockStatement).executeQuery(selectStatement);
+        verify(mockConnection).prepareStatement(selectStatement);
+        verify(mockPreparedStatement).setLong(1, timId);
+        verify(mockPreparedStatement).executeQuery();
         verify(mockRs).getString("IPV4_ADDRESS");
         verify(mockRs).getBigDecimal("LATITUDE");
         verify(mockRs).getBigDecimal("LONGITUDE");
         verify(mockRs).getInt("RSU_INDEX");
         verify(mockRs).getString("UPDATE_USERNAME");
         verify(mockRs).getString("UPDATE_PASSWORD");
-        verify(mockStatement).close();
+        verify(mockPreparedStatement).close();
         verify(mockConnection).close();
         verify(mockRs).close();
     }
@@ -90,7 +96,7 @@ public class RsuControllerTest extends TestBase<RsuController> {
         "rsu_credentials.password as update_password, ST_X(ST_AsText(rsus.geography)) as longitude, " + 
         "ST_Y(ST_AsText(rsus.geography)) as latitude, rsus.ipv4_address, tim_rsu.rsu_index from rsus " + 
         "inner join rsu_credentials on rsu_credentials.credential_id = rsus.credential_id inner join " + 
-        "tim_rsu on tim_rsu.rsu_id = rsus.rsu_id where tim_rsu.tim_id = " + timId;
+        "tim_rsu on tim_rsu.rsu_id = rsus.rsu_id where tim_rsu.tim_id = ?";
         doThrow(new SQLException()).when(mockRs).getString("IPV4_ADDRESS");
 
         // Act
@@ -98,8 +104,10 @@ public class RsuControllerTest extends TestBase<RsuController> {
 
         // Assert
         Assertions.assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, data.getStatusCode());
-        verify(mockStatement).executeQuery(selectStatement);
-        verify(mockStatement).close();
+        verify(mockConnection).prepareStatement(selectStatement);
+        verify(mockPreparedStatement).setLong(1, timId);
+        verify(mockPreparedStatement).executeQuery();
+        verify(mockPreparedStatement).close();
         verify(mockConnection).close();
         verify(mockRs).close();
     }
@@ -110,20 +118,23 @@ public class RsuControllerTest extends TestBase<RsuController> {
         String route = "I80";
         String selectStatement = "select rsu_id, ST_X(ST_AsText(geography)) as longitude, " + 
         "ST_Y(ST_AsText(geography)) as latitude, ipv4_address, primary_route, milepost from rsus " + 
-        "where primary_route like '%" + route + "%'";
+        "where primary_route like ?";
+
         // Act
         ResponseEntity<ArrayList<WydotRsu>> data = uut.selectRsusByRoute(route);
 
         // Assert
         Assertions.assertEquals(HttpStatus.OK, data.getStatusCode());
-        verify(mockStatement).executeQuery(selectStatement);
+        verify(mockConnection).prepareStatement(selectStatement);
+        verify(mockPreparedStatement).setString(1, "%" + route + "%");
+        verify(mockPreparedStatement).executeQuery();
         verify(mockRs).getInt("RSU_ID");
         verify(mockRs).getString("IPV4_ADDRESS");
         verify(mockRs).getBigDecimal("LATITUDE");
         verify(mockRs).getBigDecimal("LONGITUDE");
         verify(mockRs).getString("ROUTE");
         verify(mockRs).getDouble("MILEPOST");
-        verify(mockStatement).close();
+        verify(mockPreparedStatement).close();
         verify(mockConnection).close();
         verify(mockRs).close();
     }
@@ -134,15 +145,18 @@ public class RsuControllerTest extends TestBase<RsuController> {
         String route = "I80";
         String selectStatement = "select rsu_id, ST_X(ST_AsText(geography)) as longitude, " + 
         "ST_Y(ST_AsText(geography)) as latitude, ipv4_address, primary_route, milepost from rsus " + 
-        "where primary_route like '%" + route + "%'";
+        "where primary_route like ?";
         doThrow(new SQLException()).when(mockRs).getInt("RSU_ID");
+
         // Act
         ResponseEntity<ArrayList<WydotRsu>> data = uut.selectRsusByRoute(route);
 
         // Assert
         Assertions.assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, data.getStatusCode());
-        verify(mockStatement).executeQuery(selectStatement);
-        verify(mockStatement).close();
+        verify(mockConnection).prepareStatement(selectStatement);
+        verify(mockPreparedStatement).setString(1, "%" + route + "%");
+        verify(mockPreparedStatement).executeQuery();
+        verify(mockPreparedStatement).close();
         verify(mockConnection).close();
         verify(mockRs).close();
     }
@@ -161,7 +175,6 @@ public class RsuControllerTest extends TestBase<RsuController> {
         Assertions.assertEquals(HttpStatus.OK, result.getStatusCode());
         Assertions.assertEquals(1, result.getBody().size());
         Assertions.assertEquals(-1, result.getBody().get(0));
-
         verify(mockConnection).prepareStatement(statement);
         verify(mockPreparedStatement).setLong(1, 123);
         verify(mockPreparedStatement).executeQuery();


### PR DESCRIPTION
## Problem
`RsuController` used raw `Statement` objects, making queries harder to reason about and less aligned with best practices. Tests were also written against non-parameterized queries.

## Solution
Replaced `Statement` with `PreparedStatement` in `RsuController` to improve readability and safety, and updated tests to reflect parameterized queries.  
**No functional or behavioral changes were made to application logic.**

## Testing
- Updated existing tests to use parameterized queries
- All tests pass

## Related Work Item
These changes were made in support of [Update TIM Deposit Selection Logic to Use depositTIM](https://dev.azure.com/SOC-OIT/CDOT/_workitems/edit/437197/).