### PR TITLE
Replace Hardcoded 'Region 1' RSU TIM Exclusion With `rsu_options` Configuration

### DIFF
--- a/cv-data-controller/src/main/java/com/trihydro/cvdatacontroller/controller/RsuController.java
+++ b/cv-data-controller/src/main/java/com/trihydro/cvdatacontroller/controller/RsuController.java
@@ -102,15 +102,12 @@ public class RsuController extends BaseController {
     public ResponseEntity<ArrayList<WydotRsu>> selectRsusByGeometry(@PathVariable String geometry) {
         ArrayList<WydotRsu> rsus = new ArrayList<>();
 
-        String query = "SELECT rsu_id, ST_X(ST_AsText(geography)) AS longitude, ST_Y(ST_AsText(geography)) AS latitude, "
+        String query = "SELECT rsus.rsu_id, ST_X(ST_AsText(geography)) AS longitude, ST_Y(ST_AsText(geography)) AS latitude, "
                 + "primary_route, milepost, ipv4_address, sc.username, sc.password "
                 + "FROM rsus "
                 + "JOIN snmp_credentials AS sc ON rsus.snmp_credential_id = sc.snmp_credential_id "
-                + "WHERE rsu_id NOT IN ("
-                + "  SELECT rsu_id "
-                + "  FROM rsu_organization AS ro "
-                + "  JOIN organizations AS o ON ro.organization_id = o.organization_id "
-                + "  WHERE o.name = 'Region 1') "
+                + "JOIN rsu_options AS ro ON rsus.rsu_id = ro.rsu_id "
+                + "WHERE ro.tim_deposit = true "
                 + "AND ST_Intersects(ST_Buffer(ST_GeomFromText(?), 1), geography)";
 
         try(Connection connection = dbInteractions.getConnectionPool();

--- a/cv-data-controller/src/main/java/com/trihydro/cvdatacontroller/controller/RsuController.java
+++ b/cv-data-controller/src/main/java/com/trihydro/cvdatacontroller/controller/RsuController.java
@@ -156,7 +156,7 @@ public class RsuController extends BaseController {
                     rsu.setRsuTarget(rs.getString("IPV4_ADDRESS"));
                     rsu.setLatitude(rs.getBigDecimal("LATITUDE"));
                     rsu.setLongitude(rs.getBigDecimal("LONGITUDE"));
-                    rsu.setRoute(rs.getString("ROUTE"));
+                    rsu.setRoute(rs.getString("PRIMARY_ROUTE"));
                     rsu.setMilepost(rs.getDouble("MILEPOST"));
                     rsus.add(rsu);
                 }

--- a/cv-data-controller/src/test/java/com/trihydro/cvdatacontroller/controller/RsuControllerTest.java
+++ b/cv-data-controller/src/test/java/com/trihydro/cvdatacontroller/controller/RsuControllerTest.java
@@ -137,7 +137,7 @@ public class RsuControllerTest extends TestBase<RsuController> {
         verify(mockRs).getString("IPV4_ADDRESS");
         verify(mockRs).getBigDecimal("LATITUDE");
         verify(mockRs).getBigDecimal("LONGITUDE");
-        verify(mockRs).getString("ROUTE");
+        verify(mockRs).getString("PRIMARY_ROUTE");
         verify(mockRs).getDouble("MILEPOST");
         verify(mockPreparedStatement).close();
         verify(mockConnection).close();

--- a/cv-data-controller/src/test/java/com/trihydro/cvdatacontroller/controller/RsuControllerTest.java
+++ b/cv-data-controller/src/test/java/com/trihydro/cvdatacontroller/controller/RsuControllerTest.java
@@ -208,4 +208,37 @@ public class RsuControllerTest extends TestBase<RsuController> {
         verify(mockPreparedStatement).close();
         verify(mockConnection).close();
     }
+
+    @Test
+    public void selectRsusByGeometry_SUCCESS() throws SQLException {
+        // Arrange
+        String geometry = "POLYGON((-105 41, -104 41, -104 42, -105 42, -105 41))";
+        String selectStatement = "SELECT rsus.rsu_id, ST_X(ST_AsText(geography)) AS longitude, ST_Y(ST_AsText(geography)) AS latitude, "
+                + "primary_route, milepost, ipv4_address, sc.username, sc.password "
+                + "FROM rsus "
+                + "JOIN snmp_credentials AS sc ON rsus.snmp_credential_id = sc.snmp_credential_id "
+                + "JOIN rsu_options AS ro ON rsus.rsu_id = ro.rsu_id "
+                + "WHERE ro.tim_deposit = true "
+                + "AND ST_Intersects(ST_Buffer(ST_GeomFromText(?), 1), geography)";
+
+        // Act
+        ResponseEntity<ArrayList<WydotRsu>> data = uut.selectRsusByGeometry(geometry);
+
+        // Assert
+        Assertions.assertEquals(HttpStatus.OK, data.getStatusCode());
+        verify(mockConnection).prepareStatement(selectStatement);
+        verify(mockPreparedStatement).setString(1, geometry);
+        verify(mockPreparedStatement).executeQuery();
+        verify(mockRs).getInt("RSU_ID");
+        verify(mockRs).getString("IPV4_ADDRESS");
+        verify(mockRs).getBigDecimal("LATITUDE");
+        verify(mockRs).getBigDecimal("LONGITUDE");
+        verify(mockRs).getString("PRIMARY_ROUTE");
+        verify(mockRs).getDouble("MILEPOST");
+        verify(mockRs).getString("USERNAME");
+        verify(mockRs).getString("PASSWORD");
+        verify(mockPreparedStatement).close();
+        verify(mockConnection).close();
+        verify(mockRs).close();
+    }
 }

--- a/cv-data-controller/src/test/java/com/trihydro/cvdatacontroller/controller/RsuControllerTest.java
+++ b/cv-data-controller/src/test/java/com/trihydro/cvdatacontroller/controller/RsuControllerTest.java
@@ -241,4 +241,29 @@ public class RsuControllerTest extends TestBase<RsuController> {
         verify(mockConnection).close();
         verify(mockRs).close();
     }
+
+    @Test
+    public void selectRsusByGeometry_FAIL() throws SQLException {
+        // Arrange
+        String geometry = "POLYGON((-105 41, -104 41, -104 42, -105 42, -105 41))";
+        String selectStatement = "SELECT rsus.rsu_id, ST_X(ST_AsText(geography)) AS longitude, ST_Y(ST_AsText(geography)) AS latitude, "
+                + "primary_route, milepost, ipv4_address, sc.username, sc.password "
+                + "FROM rsus "
+                + "JOIN snmp_credentials AS sc ON rsus.snmp_credential_id = sc.snmp_credential_id "
+                + "JOIN rsu_options AS ro ON rsus.rsu_id = ro.rsu_id "
+                + "WHERE ro.tim_deposit = true "
+                + "AND ST_Intersects(ST_Buffer(ST_GeomFromText(?), 1), geography)";
+        when(mockPreparedStatement.executeQuery()).thenThrow(new SQLException());
+
+        // Act
+        ResponseEntity<ArrayList<WydotRsu>> data = uut.selectRsusByGeometry(geometry);
+
+        // Assert
+        Assertions.assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, data.getStatusCode());
+        verify(mockConnection).prepareStatement(selectStatement);
+        verify(mockPreparedStatement).setString(1, geometry);
+        verify(mockPreparedStatement).executeQuery();
+        verify(mockPreparedStatement).close();
+        verify(mockConnection).close();
+    }
 }

--- a/db-scripts/pgsql/setup/sql/1-create_all_tables.sql
+++ b/db-scripts/pgsql/setup/sql/1-create_all_tables.sql
@@ -718,3 +718,14 @@ CREATE TABLE IF NOT EXISTS rsu_organization
       ON UPDATE NO ACTION
       ON DELETE NO ACTION
 );
+
+CREATE TABLE IF NOT EXISTS public.rsu_options (
+    rsu_id integer NOT NULL,
+    tim_deposit boolean NOT NULL DEFAULT TRUE,
+    snmp_monitoring boolean NOT NULL DEFAULT FALSE,
+    CONSTRAINT rsu_options_pkey PRIMARY KEY (rsu_id),
+    CONSTRAINT fk_rsu_id FOREIGN KEY (rsu_id)
+        REFERENCES public.rsus (rsu_id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION
+);


### PR DESCRIPTION
## Problem  
The exclusion of RSUs in the **Region 1** organization from TIM deposits is currently hardcoded in the `RsuController` class.

## Solution  
The query logic has been updated to use the `tim_deposit` column in the new `rsu_options` table to determine which RSUs are eligible for delivery.

### Note
The `rsu_options` table was introduced in https://github.com/CDOT-CV/jpo-cvmanager/pull/272

## Other Changes  
Several endpoints were updated to use `PRIMARY_ROUTE` instead of `ROUTE`, as `PRIMARY_ROUTE` exists in the `rsus` table while `ROUTE` does not.

## Testing  
- All unit tests pass.

## Query Validation  
Using the following query (derived from `selectRsusByGeometry` with the geometry filter removed) and the default RSU data provided by the CV Manager:

```sql
SELECT rsus.rsu_id, ST_X(ST_AsText(geography)) AS longitude, ST_Y(ST_AsText(geography)) AS latitude,
primary_route, milepost, ipv4_address, sc.username, sc.password
FROM rsus
JOIN snmp_credentials AS sc ON rsus.snmp_credential_id = sc.snmp_credential_id
JOIN rsu_options AS ro ON rsus.rsu_id = ro.rsu_id
WHERE ro.tim_deposit = true
```
The following results were retrieved:
<img width="1597" height="181" alt="image" src="https://github.com/user-attachments/assets/7a53f99d-971d-4c1b-a6a7-4432af6de642" />

## Relevant Work Item
This PR resolves  [Update TIM Deposit Selection Logic to Use depositTIM](https://dev.azure.com/SOC-OIT/CDOT/_workitems/edit/437197/).